### PR TITLE
[marketing] fix footer on mobile

### DIFF
--- a/apps/web/src/components/footer.astro
+++ b/apps/web/src/components/footer.astro
@@ -32,13 +32,14 @@ import Link from "./link.astro";
     </a>
   </div>
   <div>
-    <div class="flex gap-4 mb-4 text-lg">
+    <div class="flex items-center justify-center gap-4 mb-4 text-lg">
       <Link to="https://discord.gg/trashdev">Discord</Link>
       <Link to="https://github.com/Hacksore/overlayed">Github</Link>
       <Link to="https://x.com/OverlayedDev">Twitter</Link>
     </div>
-    <div class="flex gap-4">
+    <div class="flex items-center justify-center gap-4">
       <Link to="/privacy">Privacy</Link>
+      <span>|</span>
       <Link to="/tos">ToS</Link>
     </div>
   </div>

--- a/apps/web/src/components/footer.astro
+++ b/apps/web/src/components/footer.astro
@@ -2,7 +2,7 @@
 import Link from "./link.astro";
 ---
 
-<footer class="py-24 max-w-[800px] mx-auto text-gray-400 text-center">
+<footer class="py-24 w-full mx-auto text-gray-400 text-center">
   <div
     class="relative flex justify-center items-center mb-24 w-full h-2 bg-gradient-to-r from-transparent via-zinc-800 to-transparent"
   >

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -53,8 +53,8 @@ import Footer from "../components/footer.astro";
         <img src="/img/resources.png" alt="Lightweight" class="w-full" />
       </Card>
     </div>
+    <Footer />
   </main>
-  <Footer />
 </Layout>
 
 <style>


### PR DESCRIPTION
This will close #6 

Will cook more if more changes requested. Some ideas I had:

- We'll have a nav w/ things spelled out so the bottom could just be icons for the socials and then the text links for privacy/tos below. This would be similar to typehero like:


💠 :octocat: 🐦 
Privacy | TOS

---

Screenshot of first iteration:

![image](https://github.com/Hacksore/overlayed/assets/44373521/fbb9c2b8-c186-48eb-bcde-a3af50fd958e)


