### PR TITLE
fix: horizontal centre hero on mobile view

### DIFF
--- a/apps/web/src/pages/canary.astro
+++ b/apps/web/src/pages/canary.astro
@@ -25,9 +25,7 @@ const [canary] = await Astro.glob("../content/canary/index.mdx");
   <main class="main-content px-8 pt-28">
     <section>
       <div class="flex flex-col">
-        <div
-          class="flex flex-col text-center items-center justify-center"
-        >
+        <div class="flex flex-col text-center items-center justify-center">
           <img
             src="/img/canary.png"
             width="256"

--- a/apps/web/src/pages/canary.astro
+++ b/apps/web/src/pages/canary.astro
@@ -26,7 +26,7 @@ const [canary] = await Astro.glob("../content/canary/index.mdx");
     <section>
       <div class="flex flex-col">
         <div
-          class="flex m-auto flex-col text-center items-center justify-center"
+          class="flex flex-col text-center items-center justify-center"
         >
           <img
             src="/img/canary.png"

--- a/apps/web/src/pages/discord.astro
+++ b/apps/web/src/pages/discord.astro
@@ -24,7 +24,7 @@ import { DISCORD_INVITE_LINK } from "../constants";
     <section>
       <div class="flex flex-col">
         <div
-          class="flex m-auto flex-col text-center items-center justify-center"
+          class="flex flex-col text-center items-center justify-center"
         >
           <img
             src="/img/discord/logo.png"

--- a/apps/web/src/pages/discord.astro
+++ b/apps/web/src/pages/discord.astro
@@ -23,9 +23,7 @@ import { DISCORD_INVITE_LINK } from "../constants";
   <main class="main-content px-8 pt-28">
     <section>
       <div class="flex flex-col">
-        <div
-          class="flex flex-col text-center items-center justify-center"
-        >
+        <div class="flex flex-col text-center items-center justify-center">
           <img
             src="/img/discord/logo.png"
             width="256"


### PR DESCRIPTION
auto-margin class was causing the hero to not be centered on mobile view. Larger viewports were not effected by this change. 

Probably should've put this on a separate branch...... (please don't hurt me seniors)