### PR TITLE
feat: add tauri_nspanel

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2474,6 +2474,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-build",
+ "tauri-nspanel",
  "tauri-plugin-single-instance",
  "tauri-plugin-websocket",
  "tauri-plugin-window-state",
@@ -3818,6 +3819,22 @@ dependencies = [
  "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-nspanel"
+version = "0.0.0"
+source = "git+https://github.com/ahkohd/tauri-nspanel?branch=v1#9bf268429c8b0bebff0f5e63a18ab51b90c728de"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "cocoa 0.25.0",
+ "core-foundation",
+ "core-graphics 0.23.2",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "tauri",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1.38.0", features = [
 tauri-plugin-websocket = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v1" }
 anyhow = "1.0.86"
 
 # macos dependencies

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -46,13 +46,13 @@ tokio = { version = "1.38.0", features = [
 tauri-plugin-websocket = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-window-state = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 tauri-plugin-single-instance = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
-tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v1" }
 anyhow = "1.0.86"
 
 # macos dependencies
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.7"
 cocoa = "0.25.0"
+tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v1" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>LSUIElement</key>
-	<true/>
-</dict>
-</plist>

--- a/apps/desktop/src-tauri/src/constants.rs
+++ b/apps/desktop/src-tauri/src/constants.rs
@@ -13,3 +13,6 @@ pub const OVERLAYED: &str = "overlayed";
 
 /// random events
 pub const SHOW_UPDATE_MODAL: &str = "show_update_modal";
+
+/// window levels
+pub const HIGHER_LEVEL_THAN_LEAGUE: i32 = 1001;

--- a/apps/desktop/src-tauri/src/constants.rs
+++ b/apps/desktop/src-tauri/src/constants.rs
@@ -15,4 +15,5 @@ pub const OVERLAYED: &str = "overlayed";
 pub const SHOW_UPDATE_MODAL: &str = "show_update_modal";
 
 /// window levels
+// NOTE: league sets it's window to 1000 so we go one higher
 pub const HIGHER_LEVEL_THAN_LEAGUE: i32 = 1001;

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -33,7 +33,7 @@ pub struct Pinned(AtomicBool);
 fn apply_macos_specifics(window: &Window) {
   window.set_transparent_titlebar(true, true);
 
-  window.set_float_panel();
+  window.set_float_panel(constants::HIGHER_LEVEL_THAN_LEAGUE);
 }
 
 fn main() {

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -31,8 +31,9 @@ pub struct Pinned(AtomicBool);
 
 #[cfg(target_os = "macos")]
 fn apply_macos_specifics(window: &Window) {
-  window.set_visisble_on_all_workspaces(true);
   window.set_transparent_titlebar(true, true);
+
+  window.set_float_panel();
 }
 
 fn main() {
@@ -41,13 +42,21 @@ fn main() {
   flags.remove(StateFlags::VISIBLE);
 
   let window_state_plugin = tauri_plugin_window_state::Builder::default().with_state_flags(flags);
-  let app = tauri::Builder::default()
+
+  let mut app = tauri::Builder::default()
     // TODO: this should work on windows
     .plugin(window_state_plugin.build())
     .plugin(tauri_plugin_websocket::init())
     .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
       println!("{}, {argv:?}, {cwd}", app.package_info().name);
-    }))
+    }));
+
+  #[cfg(target_os = "macos")]
+  {
+    app = app.plugin(tauri_nspanel::init());
+  }
+
+  app = app
     .manage(Pinned(AtomicBool::new(false)))
     .setup(|app| {
       let window = app.get_window(MAIN_WINDOW_NAME).unwrap();
@@ -95,24 +104,25 @@ fn main() {
       open_devtools,
       close_settings,
       open_settings
-    ])
-    .build(tauri::generate_context!())
-    .expect("An error occured while running the app!");
+    ]);
 
-  app.run(|app, event| match event {
-    tauri::RunEvent::WindowEvent {
-      label,
-      event: win_event,
-      ..
-    } => match win_event {
-      // NOTE: prevent destroying the window
-      tauri::WindowEvent::CloseRequested { api, .. } => {
-        let win = app.get_window(label.as_str()).unwrap();
-        win.hide().unwrap();
-        api.prevent_close();
-      }
+  app
+    .build(tauri::generate_context!())
+    .expect("An error occured while running the app!")
+    .run(|app, event| match event {
+      tauri::RunEvent::WindowEvent {
+        label,
+        event: win_event,
+        ..
+      } => match win_event {
+        // NOTE: prevent destroying the window
+        tauri::WindowEvent::CloseRequested { api, .. } => {
+          let win = app.get_window(label.as_str()).unwrap();
+          win.hide().unwrap();
+          api.prevent_close();
+        }
+        _ => {}
+      },
       _ => {}
-    },
-    _ => {}
-  })
+    });
 }

--- a/apps/desktop/src-tauri/src/window_custom.rs
+++ b/apps/desktop/src-tauri/src/window_custom.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 pub mod macos {
   use cocoa::appkit::{
-    NSMainMenuWindowLevel, NSWindow, NSWindowButton, NSWindowCollectionBehavior, NSWindowStyleMask,
+    NSWindow, NSWindowButton, NSWindowCollectionBehavior, NSWindowStyleMask,
     NSWindowTitleVisibility,
   };
   use objc::{msg_send, runtime::YES};
@@ -10,7 +10,7 @@ pub mod macos {
 
   pub trait WindowExtMacos {
     fn set_transparent_titlebar(&self, title_transparent: bool, remove_toolbar: bool);
-    fn set_float_panel(&self);
+    fn set_float_panel(&self, level: i32);
   }
 
   impl<R: Runtime> WindowExtMacos for Window<R> {
@@ -52,10 +52,10 @@ pub mod macos {
       }
     }
 
-    fn set_float_panel(&self) {
+    fn set_float_panel(&self, level: i32) {
       let panel = self.to_panel().unwrap();
 
-      panel.set_level(NSMainMenuWindowLevel + 1);
+      panel.set_level(level);
 
       #[allow(non_upper_case_globals)]
       const NSWindowStyleMaskNonActivatingPanel: i32 = 1 << 7;


### PR DESCRIPTION
This PR enables the main window to always draw over other apps (including full-screen apps), join all spaces and not collected by expose view.