### PR TITLE
feat: dynamic window level elevation

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2472,6 +2472,7 @@ dependencies = [
  "cocoa 0.25.0",
  "objc",
  "serde",
+ "system-notification",
  "tauri",
  "tauri-build",
  "tauri-nspanel",
@@ -3619,6 +3620,17 @@ dependencies = [
  "pkg-config",
  "toml 0.8.14",
  "version-compare 0.2.0",
+]
+
+[[package]]
+name = "system-notification"
+version = "0.1.0"
+source = "git+https://github.com/ahkohd/tauri-toolkit?branch=v1#6488fd7494bdfeb72856c7de5e5ae5417a83224e"
+dependencies = [
+ "block",
+ "cocoa 0.25.0",
+ "objc",
+ "tauri",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ anyhow = "1.0.86"
 objc = "0.2.7"
 cocoa = "0.25.0"
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", branch = "v1" }
+system-notification = { git = "https://github.com/ahkohd/tauri-toolkit", branch = "v1" }
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/apps/desktop/src-tauri/src/app_handle.rs
+++ b/apps/desktop/src-tauri/src/app_handle.rs
@@ -1,0 +1,44 @@
+use tauri::{AppHandle, Runtime};
+
+#[cfg(target_os = "macos")]
+use tauri_nspanel::{
+  cocoa::base::id,
+  objc::{class, msg_send, sel, sel_impl},
+};
+
+#[cfg(target_os = "macos")]
+fn nsstring_to_string(ns_string: id) -> Option<String> {
+  use std::ffi::{c_char, CStr};
+
+  let utf8: id = unsafe { msg_send![ns_string, UTF8String] };
+
+  if !utf8.is_null() {
+    Some(unsafe {
+      {
+        CStr::from_ptr(utf8 as *const c_char)
+          .to_string_lossy()
+          .into_owned()
+      }
+    })
+  } else {
+    None
+  }
+}
+
+#[cfg(target_os = "macos")]
+pub trait AppHandleExt {
+  fn frontmost_application_bundle_id() -> Option<String>;
+}
+
+#[cfg(target_os = "macos")]
+impl<R: Runtime> AppHandleExt for AppHandle<R> {
+  fn frontmost_application_bundle_id() -> Option<String> {
+    let workspace: id = unsafe { msg_send![class!(NSWorkspace), sharedWorkspace] };
+
+    let frontmost_application: id = unsafe { msg_send![workspace, frontmostApplication] };
+
+    let bundle_id: id = unsafe { msg_send![frontmost_application, bundleIdentifier] };
+
+    nsstring_to_string(bundle_id)
+  }
+}

--- a/apps/desktop/src-tauri/src/constants.rs
+++ b/apps/desktop/src-tauri/src/constants.rs
@@ -16,4 +16,6 @@ pub const SHOW_UPDATE_MODAL: &str = "show_update_modal";
 
 /// window levels
 // NOTE: league sets it's window to 1000 so we go one higher
-pub const HIGHER_LEVEL_THAN_LEAGUE: i32 = 1001;
+pub static HIGHER_LEVEL_THAN_LEAGUE: i32 = 1001;
+/// Float panel window level
+pub static OVERLAYED_NORMAL_LEVEL: i32 = 8;


### PR DESCRIPTION
This PR implements dynamic window level elevation. When the League of Legends app is activated, the Overlay panel is moved to the highest level so that it can display above the League of Legends app. Once deactivated, the Overlay panel level is reduced to the floating panel level.