### PR TITLE
refactor: Put configuration in a separate tab

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-slider": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",
+    "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.5",
     "@radix-ui/react-tooltip": "^1.1.7",

--- a/apps/desktop/src/components/ui/switch.tsx
+++ b/apps/desktop/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/utils/tw";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -36,7 +36,7 @@
 
     --error-label: 0 84.2% 60.2%;
 
-    --ring: 240 5% 64.9%;
+    --ring: var(--primary);
 
     --radius: 0.5rem;
 
@@ -84,7 +84,7 @@
 
     --error-label: 0 92.2% 64.9%;
 
-    --ring: 240 3.7% 15.9%;
+    --ring: var(--primary);
   }
 }
 

--- a/apps/desktop/src/views/settings/account.tsx
+++ b/apps/desktop/src/views/settings/account.tsx
@@ -5,7 +5,6 @@ import { saveWindowState, StateFlags } from "@tauri-apps/plugin-window-state";
 
 import { invoke } from "@tauri-apps/api/core";
 import { usePlatformInfo } from "@/hooks/use-platform-info";
-import Config from "@/config";
 
 import {
   Dialog,
@@ -18,13 +17,9 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { useEffect, useState } from "react";
-import { Checkbox } from "@/components/ui/checkbox";
-import { emit } from "@tauri-apps/api/event";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import type { VoiceUser } from "@/types";
-import { useConfigValue } from "@/hooks/use-config-value";
 import * as shell from "@tauri-apps/plugin-shell";
-import { Input } from "@/components/ui/input";
 
 export const Developer = () => {
   const platformInfo = usePlatformInfo();
@@ -69,76 +64,32 @@ const canaryVersionToCommit = (version: string) => {
 
 export const AppInfo = () => {
   const platformInfo = usePlatformInfo();
-  const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
-  const { value: opacity } = useConfigValue("opacity");
 
   const urlForVersion = platformInfo.canary
     ? `https://github.com/overlayeddev/overlayed/commit/${canaryVersionToCommit(platformInfo.appVersion)}`
     : `https://github.com/overlayeddev/overlayed/releases/tag/v${platformInfo.appVersion}`;
 
   return (
-    <div>
-      <div className="flex items-center pb-2">
-        <Checkbox
-          id="notification"
-          checked={showOnlyTalkingUsers}
-          onCheckedChange={async () => {
-            const newBool = !showOnlyTalkingUsers;
-            await Config.set("showOnlyTalkingUsers", newBool);
-
-            await emit("config_update", await Config.getConfig());
-          }}
-        />
-        <label
-          htmlFor="notification"
-          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Only show users who are speaking
-        </label>
+    <div className="flex items-center gap-2 pb-4 text-zinc-400">
+      <div>
+        <p className="text-sm">
+          <strong>OS</strong> {platformInfo.os} {platformInfo.kernalVersion} {platformInfo.arch}
+        </p>
       </div>
-      <div className="flex items-center pb-2">
-        <Input
-          id="opacity"
-          type="number"
-          min={1}
-          max={100}
-          value={opacity}
-          onChange={async event => {
-            const newOpacity = event.target.value;
-            await Config.set("opacity", Number(newOpacity));
-
-            await emit("config_update", await Config.getConfig());
-          }}
-          className="w-20"
-        />
-        <label
-          htmlFor="opacity"
-          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Overlay opacity
-        </label>
+      <span className="text-xs">/</span>
+      <div>
+        <p className="text-sm">
+          <strong>Tauri</strong> {platformInfo.tauriVersion}
+        </p>
       </div>
-      <div className="flex items-center gap-2 pb-4 text-zinc-400">
-        <div>
-          <p className="text-sm">
-            <strong>OS</strong> {platformInfo.os} {platformInfo.kernalVersion} {platformInfo.arch}
-          </p>
-        </div>
-        <span className="text-xs">/</span>
-        <div>
-          <p className="text-sm">
-            <strong>Tauri</strong> {platformInfo.tauriVersion}
-          </p>
-        </div>
-        <span className="text-sm">/</span>
-        <div>
-          <p className="text-sm">
-            <strong>App</strong>{" "}
-            <a target="_blank" rel="noreferrer" href={urlForVersion}>
-              {platformInfo.appVersion}
-            </a>
-          </p>
-        </div>
+      <span className="text-sm">/</span>
+      <div>
+        <p className="text-sm">
+          <strong>App</strong>{" "}
+          <a target="_blank" rel="noreferrer" href={urlForVersion}>
+            {platformInfo.appVersion}
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/apps/desktop/src/views/settings/configuration.tsx
+++ b/apps/desktop/src/views/settings/configuration.tsx
@@ -1,0 +1,55 @@
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import Config from "@/config";
+import { useConfigValue } from "@/hooks/use-config-value";
+import { emit } from "@tauri-apps/api/event";
+
+export const Configuration = () => {
+  const { value: showOnlyTalkingUsers } = useConfigValue("showOnlyTalkingUsers");
+  const { value: opacity } = useConfigValue("opacity");
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="notification"
+          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Only show users who are speaking
+        </label>
+        <Switch
+          id="notification"
+          checked={showOnlyTalkingUsers}
+          onCheckedChange={async () => {
+            const newBool = !showOnlyTalkingUsers;
+            await Config.set("showOnlyTalkingUsers", newBool);
+
+            await emit("config_update", await Config.getConfig());
+          }}
+        />
+      </div>
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="opacity"
+          className="ml-2 text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Overlay opacity
+        </label>
+        <Input
+          id="opacity"
+          type="number"
+          min={1}
+          max={100}
+          value={opacity}
+          onChange={async event => {
+            const newOpacity = event.target.value;
+            await Config.set("opacity", Number(newOpacity));
+
+            await emit("config_update", await Config.getConfig());
+          }}
+          className="w-20"
+        />
+      </div>
+    </div>
+  );
+};

--- a/apps/desktop/src/views/settings/index.tsx
+++ b/apps/desktop/src/views/settings/index.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { usePlatformInfo } from "@/hooks/use-platform-info";
 import { SiX, SiTwitch, SiDiscord, type IconType } from "@icons-pack/react-simple-icons";
 import type { Update } from "@tauri-apps/plugin-updater";
+import { Configuration } from "./configuration";
 
 function Link({ icon: Icon, url }: { icon: IconType; url: string }) {
   return (
@@ -26,8 +27,9 @@ export const SettingsView = ({ update }: { update: Update | null }) => {
           setCurrentTab(value);
         }}
       >
-        <TabsList className="grid w-full grid-cols-2">
+        <TabsList className="grid w-full grid-cols-3 rounded-t-none">
           <TabsTrigger value="account">General</TabsTrigger>
+          <TabsTrigger value="configuration">Configuration</TabsTrigger>
           <TabsTrigger value="join-history">Join History</TabsTrigger>
         </TabsList>
         {canary && (
@@ -41,6 +43,9 @@ export const SettingsView = ({ update }: { update: Update | null }) => {
         <div className="p-4 pt-0">
           <TabsContent tabIndex={-1} value="account">
             <Account />
+          </TabsContent>
+          <TabsContent tabIndex={-1} value="configuration">
+            <Configuration />
           </TabsContent>
           <TabsContent tabIndex={-1} forceMount value="join-history">
             <div style={{ display: currentTab === "join-history" ? "block" : "none" }}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.1
         version: 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.1.3
+        version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2407,6 +2410,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-radio-group@1.1.3':
     resolution: {integrity: sha512-x+yELayyefNeKeTx4fjK6j99Fs6c4qKm3aY38G3swQVTN6xMpsrbigC0uHs2L//g8q4qR7qOcww8430jJmi2ag==}
     peerDependencies:
@@ -2516,13 +2532,22 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-switch@1.0.3':
-    resolution: {integrity: sha512-mxm87F88HyHztsI7N+ZUmEoARGkC22YVW5CaC+Byc+HRpuvCrOBPTAnXgf+tZ/7i0Sg/eOePGdMhUKhPaQEqow==}
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.1.3':
+    resolution: {integrity: sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0
-      react-dom: ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8879,6 +8904,15 @@ snapshots:
       '@types/react': 18.3.18
       '@types/react-dom': 18.3.5(@types/react@18.3.18)
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.18
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+
   '@radix-ui/react-radio-group@1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.24.7
@@ -9025,16 +9059,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
-  '@radix-ui/react-switch@1.0.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-slot@1.1.2(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.24.7
-      '@radix-ui/primitive': 1.0.1
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.18)(react@18.3.1)
-      '@radix-ui/react-context': 1.0.1(@types/react@18.3.18)(react@18.3.1)
-      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.18)(react@18.3.1)
-      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.18)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.0.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.18
+
+  '@radix-ui/react-switch@1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.18)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.18)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -9244,7 +9284,7 @@ snapshots:
       '@radix-ui/react-separator': 1.0.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slider': 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.1.1(@types/react@18.3.18)(react@18.3.1)
-      '@radix-ui/react-switch': 1.0.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-switch': 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tabs': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-tooltip': 1.1.7(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.18)(react@18.3.1)


### PR DESCRIPTION
Hello,

In this PR, I’ve moved the configuration settings to a separate tab to make the UI cleaner and more organized.
Let me know if you have any suggestions or if you'd like any adjustments! 😊

## Technical information

- Updated the `--ring` variable to improve accessibility.  
- Added the `Switch` component from shadcn.  

## Screenshots

<img width="616" alt="Screenshot 2025-02-08 at 12 30 18" src="https://github.com/user-attachments/assets/e7809cae-edcf-4bf1-ae8f-c47bb76fb5f0" />
<img width="628" alt="Screenshot 2025-02-08 at 12 18 35" src="https://github.com/user-attachments/assets/faa1cf19-c47f-401b-8283-7d449c352fc4" />
<img width="618" alt="Screenshot 2025-02-08 at 12 18 48" src="https://github.com/user-attachments/assets/00b1dca2-71a9-464c-8519-8c700c0b48a1" />
